### PR TITLE
Fix CircleCI

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,5 +27,5 @@ Rails.application.configure do
     "Cache-Control" => "public, max-age=31557600",
   }
   config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST") }
-  config.action_mailer.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))
+  # config.action_mailer.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,11 +21,11 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
   config.active_record.dump_schema_after_migration = false
-    config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
+    config.middleware.use Rack::CanonicalHost, ENV["APPLICATION_HOST"]
   config.middleware.use Rack::Deflater
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=31557600",
   }
-  config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST") }
+  config.action_mailer.default_url_options = { host: ENV["APPLICATION_HOST"] }
   # config.action_mailer.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,7 +6,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
   config.assets.js_compressor = :uglifier
   config.assets.compile = false
-  config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))
   config.active_storage.service = :local
   config.log_level = :debug
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
## Description
- Use `[]` instead of `.fetch` when obtaining environment variables to avoid exceptions since environment variables are fed into the application upon Docker image deployment