### PR TITLE
Remove old columns from Voter table

### DIFF
--- a/rails-app/db/migrate/20190326023343_remove_old_columns_from_voters.rb
+++ b/rails-app/db/migrate/20190326023343_remove_old_columns_from_voters.rb
@@ -1,0 +1,16 @@
+class RemoveOldColumnsFromVoters < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :voters, :voterID, :integer
+    remove_column :voters, :last_name, :string
+    remove_column :voters, :first_name, :string
+    remove_column :voters, :middle_name, :string
+    remove_column :voters, :address, :string
+    remove_column :voters, :city, :string
+    remove_column :voters, :state, :string
+    remove_column :voters, :zip, :string
+    remove_column :voters, :email, :string
+    remove_column :voters, :phone, :string
+    remove_column :voters, :date_of_birth, :string
+    remove_column :voters, :party_affiliation, :string
+  end
+end

--- a/rails-app/db/schema.rb
+++ b/rails-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_07_021619) do
+ActiveRecord::Schema.define(version: 2019_03_26_023343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,18 +28,6 @@ ActiveRecord::Schema.define(version: 2019_03_07_021619) do
   end
 
   create_table "voters", force: :cascade do |t|
-    t.integer "voterID"
-    t.string "last_name"
-    t.string "first_name"
-    t.string "middle_name"
-    t.string "address"
-    t.string "city"
-    t.string "state"
-    t.string "zip"
-    t.string "email"
-    t.string "phone"
-    t.string "date_of_birth"
-    t.string "party_affiliation"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "lVoterUniqueID"

--- a/rails-app/spec/factories/voters.rb
+++ b/rails-app/spec/factories/voters.rb
@@ -1,16 +1,19 @@
 FactoryBot.define do
   factory :voter do
-    voterID { "1" }
-    last_name { "Aaby" }
-    first_name { "Dorothy" }
-    middle_name { " " }
-    address { "123 N Main Street" }
-    city { "Orange" }
-    state { "CA" }
-    zip { "92866" }
-    email { "d.aaby123@gmail.com" }
-    phone { "714-123-4567" }
-    date_of_birth { "01/02/1990" }
-    party_affiliation { "Democrat" }
+    sequence(:lVoterUniqueID) { |i| i }
+    sequence(:sAffNumber) { |i| i }
+    sequence(:szStateVoterID) { |i| i }
+    sVoterTitle { "Mx" }
+    szNameLast { "Smith" }
+    szNameFirst { "John" }
+    szNameMiddle { "Doe" }
+    sNameSuffix { "II" }
+    sGender { "M" }
+    szSitusAddress { "123 Main St" }
+    szSitusCity { "Orange" }
+    sSitusState { "CA" }
+    sSitusZip { 98265 }
+    sHouseNum { 1 }
+    sPrecinctID { 1 }
   end
 end


### PR DESCRIPTION

## Description
- Remove old and redundant columns from Voter table. These columns' values are already captured in other columns in the Voters table.


## GitHub Issue
https://github.com/ChapmanCPSC/SE-498_01/issues/81

## Pull Request Changes
- Removed old/redundant columns from Voters postgresql table including, voterID, last_name, first_name, middle_name, address, city, state, zip, email, phone, date_of_birth, and party_affiliation.

