### PR TITLE
Expose rails service

### DIFF
--- a/config/deploy/staging/ingress.yml
+++ b/config/deploy/staging/ingress.yml
@@ -21,3 +21,10 @@ spec:
             backend:
               serviceName: react-cluster-ip-service
               servicePort: 80
+    - host: api.quartiledocs.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: rails-cluster-ip-service
+              servicePort: 80

--- a/config/deploy/staging/service.yaml
+++ b/config/deploy/staging/service.yaml
@@ -10,7 +10,7 @@ spec:
     component: rails
   ports:
     - name: api-port
-      port: 3000
+      port: 80
       targetPort: 3000
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description
- Use api.quartiledocs.com

## GitHub Issue
Related to #80 

## Pull Request Changes
- Expose the rails service on `http://api.quartiledocs.com` by adding an ingress