### PR TITLE
Add logic to use production graphql endpoint

### DIFF
--- a/react-app/src/Components/Canvas.js
+++ b/react-app/src/Components/Canvas.js
@@ -11,9 +11,16 @@ class Canvas extends Component {
   constructor(props) {
     super(props);
 
-    this.client = new ApolloClient({
-      uri: "http://192.168.99.100:3000/graphql"
-    });
+    if (process.env.NODE_ENV == 'production') {
+      this.client = new ApolloClient({
+        uri: "http://api.quartiledocs.com/graphql"
+      });
+    } else {
+      this.client = new ApolloClient({
+        uri: "http://localhost:3000/graphql"
+      });
+    }
+
 
     this.index = 0;
     this.state = {


### PR DESCRIPTION
## Description
- Add react-app environment variable logic to differentiate production vs development vs testing

## Pull Request Changes
- Add logic to test if node app is in production

## Caveat
- CORS error when attempting to access graphql endpoint from production build using local machines