### PR TITLE
Update Graphql Configuration

### DIFF
--- a/rails-app/Gemfile
+++ b/rails-app/Gemfile
@@ -79,4 +79,4 @@ gem 'bullet', group: [:development, :test]
 gem 'delayed_job_active_record'
 gem 'rack-timeout', group: :production
 
-gem 'graphiql-rails', group: :development
+gem 'graphiql-rails'

--- a/react-app/src/Components/Canvas.js
+++ b/react-app/src/Components/Canvas.js
@@ -13,7 +13,7 @@ class Canvas extends Component {
 
     if (process.env.NODE_ENV == 'production') {
       this.client = new ApolloClient({
-        uri: "http://api.quartiledocs.com/graphql"
+        uri: "https://api.quartiledocs.com/graphql"
       });
     } else {
       this.client = new ApolloClient({


### PR DESCRIPTION
## Description
- Update react-app graphql query string from http to https
- Remove development group tag on graphiql gem to enable use in production

## GitHub Issue
NA

## Pull Request Changes
- Change react app graphql query string from "http://api.quartiledocs.com/graphql" to "https://api.quartiledocs.com/graphql"
- Remove "group: :production" from "graphiql-rails" gem in rails-app

