### PR TITLE
removed webkit default styling on buttons

### DIFF
--- a/react-app/src/Components/Canvas.css
+++ b/react-app/src/Components/Canvas.css
@@ -165,7 +165,10 @@
 }
 
 .reject {
-  display: table-cell;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  opacity: 1;
+  display: inline-block;
   height: 70px;
   width: 70px;
   margin: -3px 37px 37px;
@@ -184,7 +187,10 @@
   padding: 0px;
 }
 .accept {
-  display: table-cell;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  opacity: 1;
+  display: inline-block;
   height: 70px;
   width: 70px;
   margin: -2px 37px 37px;


### PR DESCRIPTION
## Description
removed webkit default styling on buttons so buttons should look normal on chrome and safari on mobile devices

## GitHub Issue
N/A

## Pull Request Changes
removed webkit default styling on buttons so buttons should look normal on chrome and safari on mobile devices

## Screenshots (optional)
N/A
