### PR TITLE
Update voterByPrecinct query to use left outer join

### DIFF
--- a/rails-app/app/graphql/types/query_type.rb
+++ b/rails-app/app/graphql/types/query_type.rb
@@ -36,7 +36,7 @@ module Types
       description "Find Voter by sPrecinctID"
     end
     def voter_by_precinct()
-      Voter.where(sPrecinctID: Setting.precinct_id)
+      Voter.left_outer_joins(:visits).where( visits:{ voter_id:nil }).where(sPrecinctID: Setting.precinct_id)
     end
 
   end


### PR DESCRIPTION
## Description
Describe your changes made in the context of a user/technical user.
- Added left_outter_join to  `voterByPrecinct` query so it will only return voters that have not been visited

## GitHub Issue
Place a link to the GitHub issue:
#108 

## Pull Request Changes
List changes made in the context of a developer.
- Added left_outter_join to  `voterByPrecinct` query so it will only return voters that have not been visited

## Screenshots (optional)


<img width="1064" alt="Screen Shot 2019-04-13 at 12 48 19 PM" src="https://user-images.githubusercontent.com/27448527/56084640-9977b380-5dea-11e9-933d-d2173e478f58.png">
