### PR TITLE
Add Global Password That Can Be Changed

### DIFF
--- a/rails-app/app/assets/stylesheets/main.css
+++ b/rails-app/app/assets/stylesheets/main.css
@@ -178,6 +178,16 @@ iframe {
   z-index: 1;
 }
 
+.input-title {
+  position: relative;
+  display: block;
+  height: 30px;
+  text-align: center;
+  font-family: Ubuntu-Bold;
+  font-size: 18px;
+  color: #8f8fa1;
+}
+
 .input100 {
   position: relative;
   display: block;

--- a/rails-app/app/controllers/settings_controller.rb
+++ b/rails-app/app/controllers/settings_controller.rb
@@ -1,10 +1,12 @@
 class SettingsController < ApplicationController
   def index
     @precinct_id = Setting['precinct_id']
+    @canvasser_password = Setting['canvasser_password']
   end
 
   def update
     Setting.precinct_id = params[:precinct_id]
+    Setting.canvasser_password = params[:canvasser_password]
     redirect_to settings_path
   end
 

--- a/rails-app/app/graphql/types/query_type.rb
+++ b/rails-app/app/graphql/types/query_type.rb
@@ -40,7 +40,7 @@ module Types
     end
 
     field :get_cavasser_password, String, null: false do
-      description "Retreive cavasser password set up admin"
+      description "Retreive cavasser password"
     end
     def get_cavasser_password()
       Setting['canvasser_password']

--- a/rails-app/app/graphql/types/query_type.rb
+++ b/rails-app/app/graphql/types/query_type.rb
@@ -39,5 +39,12 @@ module Types
       Voter.left_outer_joins(:visits).where( visits:{ voter_id:nil }).where(sPrecinctID: Setting.precinct_id)
     end
 
+    field :get_cavasser_password, String, null: false do
+      description "Retreive cavasser password set up admin"
+    end
+    def get_cavasser_password()
+      Setting['canvasser_password']
+    end
+
   end
 end

--- a/rails-app/app/graphql/types/query_type.rb
+++ b/rails-app/app/graphql/types/query_type.rb
@@ -39,10 +39,10 @@ module Types
       Voter.left_outer_joins(:visits).where( visits:{ voter_id:nil }).where(sPrecinctID: Setting.precinct_id)
     end
 
-    field :get_cavasser_password, String, null: false do
-      description "Retreive cavasser password"
+    field :get_canvasser_password, String, null: false do
+      description "Retreive canvasser password"
     end
-    def get_cavasser_password()
+    def get_canvasser_password()
       Setting['canvasser_password']
     end
 

--- a/rails-app/app/views/settings/index.html.erb
+++ b/rails-app/app/views/settings/index.html.erb
@@ -6,8 +6,17 @@
 				Admin Dashboard
 			</span>
 
+			<!-- Update Prcinct ID -->
+
 			<div class="wrap-input100 validate-input" data-validate="Please enter a Precinct ID">
 				<input class="input100" type="text" name="precinct_id" value=<%= @precinct_id %> >
+				<span class="focus-input100"></span>
+			</div>
+
+			<!-- Update Password -->
+
+			<div class="wrap-input100 validate-input" data-validate="Please enter a password">
+				<input class="input100" type="text" name="canvasser_password" value=<%= @canvasser_password %> >
 				<span class="focus-input100"></span>
 			</div>
 
@@ -15,10 +24,11 @@
 				<button class="contact100-form-btn" type="submit">
 					<span>
 						<i class="fa fa-paper-plane-o m-r-6" aria-hidden="true"></i>
-						Update
+						update all
 					</span>
 				</button>
 			</div>
+
 		</form>
 	</div>
 </div>

--- a/rails-app/app/views/settings/index.html.erb
+++ b/rails-app/app/views/settings/index.html.erb
@@ -8,13 +8,18 @@
 
 			<!-- Update Prcinct ID -->
 
+			<div class="input-title">
+				Precinct ID
+			</div>
 			<div class="wrap-input100 validate-input" data-validate="Please enter a Precinct ID">
 				<input class="input100" type="text" name="precinct_id" value=<%= @precinct_id %> >
 				<span class="focus-input100"></span>
 			</div>
 
 			<!-- Update Password -->
-
+			<div class="input-title">
+				Canvasser Password
+			</div>
 			<div class="wrap-input100 validate-input" data-validate="Please enter a password">
 				<input class="input100" type="text" name="canvasser_password" value=<%= @canvasser_password %> >
 				<span class="focus-input100"></span>
@@ -24,7 +29,7 @@
 				<button class="contact100-form-btn" type="submit">
 					<span>
 						<i class="fa fa-paper-plane-o m-r-6" aria-hidden="true"></i>
-						update all
+						update
 					</span>
 				</button>
 			</div>

--- a/rails-app/config/app.yml
+++ b/rails-app/config/app.yml
@@ -1,6 +1,7 @@
 # config/app.yml for rails-settings-cached
 defaults: &defaults
   precinct_id: 68315
+  canvasser_password: "password"
 
 development:
   <<: *defaults

--- a/rails-app/spec/features/settings_spec.rb
+++ b/rails-app/spec/features/settings_spec.rb
@@ -2,11 +2,13 @@ require "rails_helper"
 
 RSpec.describe "Settings page", type: :feature do
 
-  it "updates the precinct id global variable" do
+  it "updates the precinct id and canvasser_password global variable" do
     visit settings_path
     fill_in "precinct_id", with: 12345
-    click_on "Update"
+    fill_in "canvasser_password", with: "password"
+    click_on "update"
     expect(page).to have_selector("input[value='12345']")
+    expect(page).to have_selector("input[value='password']")
   end
 
 end


### PR DESCRIPTION
## Description
Describe your changes made in the context of a user/technical user.
- Add global variable `canvasser_password` with default set to "password"
- Add text field on Admin Dashboard
- Add query `getCanvasserPassword` which returns the value of `canvasser_password`
- Update styling on Admin Dashboard

## GitHub Issue
Place a link to the GitHub issue:
#113 

## Pull Request Changes
List changes made in the context of a developer.
- Add global variable `canvasser_password` with default set to "password"
- Add text field on Admin Dashboard
- Add query `getCanvasserPassword` which returns the value of `canvasser_password`
- Update styling on Admin Dashboard



## Screenshots (optional)
<img width="658" alt="Screen Shot 2019-04-13 at 12 39 22 PM" src="https://user-images.githubusercontent.com/27448527/56084731-1b1c1100-5dec-11e9-80d4-c0e3e6419e56.png">


