### PR TITLE
Add note to voter

### DIFF
--- a/rails-app/Gemfile.lock
+++ b/rails-app/Gemfile.lock
@@ -24,18 +24,6 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activeadmin (1.4.3)
-      arbre (>= 1.1.1)
-      coffee-rails
-      formtastic (~> 3.1)
-      formtastic_i18n
-      inherited_resources (>= 1.9.0)
-      jquery-rails (>= 4.2.0)
-      kaminari (>= 0.15)
-      railties (>= 4.2, < 5.3)
-      ransack (>= 1.8.7)
-      sass (~> 3.1)
-      sprockets (< 4.1)
     activejob (5.2.2)
       activesupport (= 5.2.2)
       globalid (>= 0.3.6)
@@ -56,8 +44,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    arbre (1.1.1)
-      activesupport (>= 3.0.0)
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
@@ -112,13 +98,6 @@ GEM
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    coffee-rails (4.2.2)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -191,9 +170,6 @@ GEM
       railties (>= 4.2.0)
     ffi (1.10.0)
     ffi (1.10.0-x64-mingw32)
-    formtastic (3.1.5)
-      actionpack (>= 3.2.13)
-    formtastic_i18n (0.6.0)
     formulaic (0.4.1)
       activesupport
       capybara
@@ -211,25 +187,13 @@ GEM
       railties
       sprockets-rails
     graphql (1.9.3)
-    has_scope (0.7.2)
-      actionpack (>= 4.1)
-      activesupport (>= 4.1)
     hashdiff (0.3.8)
     high_voltage (3.1.0)
     honeybadger (4.2.1)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    inherited_resources (1.9.0)
-      actionpack (>= 4.2, < 5.3)
-      has_scope (~> 0.6)
-      railties (>= 4.2, < 5.3)
-      responders
     io-like (0.3.0)
-    jquery-rails (4.3.3)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.1.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -328,11 +292,6 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.2)
-    ransack (2.1.1)
-      actionpack (>= 5.0)
-      activerecord (>= 5.0)
-      activesupport (>= 5.0)
-      i18n
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -475,7 +434,6 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
-  activeadmin
   autoprefixer-rails
   awesome_print
   bootsnap

--- a/rails-app/app/controllers/api/v1/voters_controller.rb
+++ b/rails-app/app/controllers/api/v1/voters_controller.rb
@@ -18,6 +18,16 @@ module Api
         end
       end
 
+      def update
+        voter = Voter.find_by_id(params[:id])
+        voter.note = params[:note]
+        if voter.save
+          render json: {status: 'SUCCESS', id: params[:id]},status: :ok
+        else
+          render json: {status: 'FAILED', id: params[:id]}, status: :unprocessable_entity
+        end
+      end
+
     end
   end
 end

--- a/rails-app/app/controllers/settings_controller.rb
+++ b/rails-app/app/controllers/settings_controller.rb
@@ -2,11 +2,13 @@ class SettingsController < ApplicationController
   def index
     @precinct_id = Setting['precinct_id']
     @canvasser_password = Setting['canvasser_password']
+    @note = Setting['note']
   end
 
   def update
     Setting.precinct_id = params[:precinct_id]
     Setting.canvasser_password = params[:canvasser_password]
+    Setting.note = params[:note]
     redirect_to settings_path
   end
 

--- a/rails-app/app/graphql/types/query_type.rb
+++ b/rails-app/app/graphql/types/query_type.rb
@@ -46,5 +46,18 @@ module Types
       Setting['canvasser_password']
     end
 
+    field :get_note_by_id, String, null: true do
+      description "Retrieve note for voter"
+      argument :id, ID, required: true
+    end
+    def get_note_by_id(id:)
+      voter_note = Voter.find(id).note
+      if voter_note.nil?
+        Setting['note']
+      else
+        voter_note
+      end
+    end
+
   end
 end

--- a/rails-app/app/graphql/types/voter_type.rb
+++ b/rails-app/app/graphql/types/voter_type.rb
@@ -65,5 +65,6 @@ module Types
     field :sDistrictID_5, String, null: true, hash_key: "sDistrictID_5"
     field :iSubDistrict_5, String, null: true, hash_key: "iSubDistrict_5"
     field :szDistrictName_5, String, null: true, hash_key: "szDistrictName_5"
+    field :note, String, null: true, hash_key: "note"
   end
 end

--- a/rails-app/app/views/settings/index.html.erb
+++ b/rails-app/app/views/settings/index.html.erb
@@ -25,6 +25,14 @@
 				<span class="focus-input100"></span>
 			</div>
 
+			<div class="input-title">
+				Default Voter Note
+			</div>
+			<div class="wrap-input100 validate-input" data-validate="Please enter a voter note">
+				<input class="input100" type="text" name="note" value=<%= @note %> >
+				<span class="focus-input100"></span>
+			</div>
+
 			<div class="container-contact100-form-btn">
 				<button class="contact100-form-btn" type="submit">
 					<span>

--- a/rails-app/config/app.yml
+++ b/rails-app/config/app.yml
@@ -2,6 +2,7 @@
 defaults: &defaults
   precinct_id: 68315
   canvasser_password: "password"
+  note: ""
 
 development:
   <<: *defaults

--- a/rails-app/db/migrate/20190418024842_add_note_to_voter.rb
+++ b/rails-app/db/migrate/20190418024842_add_note_to_voter.rb
@@ -1,0 +1,5 @@
+class AddNoteToVoter < ActiveRecord::Migration[5.2]
+  def change
+    add_column :voters, :note, :string
+  end
+end

--- a/rails-app/db/schema.rb
+++ b/rails-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_08_171610) do
+ActiveRecord::Schema.define(version: 2019_04_18_024842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 2019_04_08_171610) do
     t.string "sDistrictID_5", default: "none"
     t.string "iSubDistrict_5", default: "none"
     t.string "szDistrictName_5", default: "none"
+    t.string "note"
   end
 
   add_foreign_key "visits", "voters"

--- a/rails-app/spec/controllers/api/v1/voters_controller_spec.rb
+++ b/rails-app/spec/controllers/api/v1/voters_controller_spec.rb
@@ -41,4 +41,11 @@ RSpec.describe Api::V1::VotersController, type: :controller do
       expect ( '{:status, :message, :data}')
     end
   end
+
+  describe '#update' do
+    it 'should update the voter object with a note' do
+      patch :update, params: {id:voter.id, note:"foobar"}
+      expect(Voter.find_by_id(voter.id).note).to eq("foobar")
+    end
+  end
 end


### PR DESCRIPTION
## Description
- Add custom note field per voter
- Add global variable for the default note
- Add `get_note_by_id(id:)` graphql query that sends you either the default note if there is an empty string or the custom user note
- Add `PATCH` route for voter that updates the user custom note
```
PATCH /api/v1/voters/1
{
note: "foobar"
}
```

## GitHub Issue
#133

## Pull Request Changes
- Add GraphQL API to fetch a note
- Add PATCH endpoint to update a note

## Screenshots
If default note then returns the empty string
![image](https://user-images.githubusercontent.com/25378966/56335520-b9440a00-6151-11e9-91e4-09bedfeb8eb0.png)
If there is a custom note, then returns the custom note
![image](https://user-images.githubusercontent.com/25378966/56335596-f8725b00-6151-11e9-8c05-5064683d16e6.png)
