### PR TITLE
Remove drop active admin comments table migration file

### DIFF
--- a/rails-app/db/migrate/20190408171610_drop_active_admin_comments.rb
+++ b/rails-app/db/migrate/20190408171610_drop_active_admin_comments.rb
@@ -1,6 +1,0 @@
-class DropActiveAdminComments < ActiveRecord::Migration[5.2]
-  def change
-    drop_table :active_admin_comments
-    drop_table :admin_users
-  end
-end


### PR DESCRIPTION
## Description
Describe your changes made in the context of a user/technical user.
- Removed `drop active admin comments` migration file
- Rails was not able to migrate db because it was trying to drop `active admin comments` which did not exist

## GitHub Issue
Place a link to the GitHub issue:
N/A

## Pull Request Changes
List changes made in the context of a developer.
- Removed `drop active admin comments` migration file
- Rails was not able to migrate db because it was trying to drop `active admin comments` which did not exist

