### PR TITLE
Add button to reset Visit table

### DIFF
--- a/rails-app/app/controllers/settings_controller.rb
+++ b/rails-app/app/controllers/settings_controller.rb
@@ -14,4 +14,10 @@ class SettingsController < ApplicationController
     redirect_to settings_path
   end
 
+  def delete_visits
+    Visit.delete_all
+    flash[:notice] = "All visit records deleted"
+    redirect_to settings_path
+  end
+
 end

--- a/rails-app/app/views/settings/index.html.erb
+++ b/rails-app/app/views/settings/index.html.erb
@@ -1,3 +1,4 @@
+<p id="notice"><%= notice %></p>
 <div class="container-contact100">
 
 	<div class="wrap-contact100">
@@ -40,6 +41,10 @@
 						update
 					</span>
 				</button>
+			</div>
+
+			<div class="container-contact100-form-btn">
+        <%= link_to 'Reset Visited Records', delete_visits_path, class: 'contact100-form-btn' %>
 			</div>
 
 		</form>

--- a/rails-app/config/routes.rb
+++ b/rails-app/config/routes.rb
@@ -25,5 +25,6 @@ Rails.application.routes.draw do
 
   get '/settings' => 'settings#index'
   post '/settings' => 'settings#update'
+  get '/delete_visits' => 'settings#delete_visits'
 
 end

--- a/rails-app/spec/factories/visits.rb
+++ b/rails-app/spec/factories/visits.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :visit do
-    
+    voter_id { nil }
   end
 end

--- a/rails-app/spec/features/settings_spec.rb
+++ b/rails-app/spec/features/settings_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Settings page", type: :feature do
+  let(:voter) { create(:voter) }
+  let(:visit1) { create(:visit, voter_id: voter.id) }
 
   it "updates the precinct id and canvasser_password global variable" do
     visit settings_path
@@ -8,6 +10,13 @@ RSpec.describe "Settings page", type: :feature do
     fill_in "canvasser_password", with: "password"
     click_on "update"
     expect(page).to have_selector("textarea", :text => "12345,67890")
+  end
+
+  it "deletes all the visit records" do
+    visit settings_path
+    click_on "Reset Visited Records"
+    expect(page).to have_content("All visit records deleted")
+    expect(Visit.count).to eq 0
   end
 
 end


### PR DESCRIPTION
## Description
- Adds a button to the admin dashboard to reset the Visit table

## GitHub Issue
#123 

## Pull Request Changes
- Add controller method `delete_visits`
- Add flash notice to admin dashboard
- Add test to check if Visits are deleted

## Screenshots
![image](https://user-images.githubusercontent.com/25378966/56550125-9d69ab00-6539-11e9-9010-d4d2b8a38a01.png)


