### PR TITLE
Added Style to "Export to CSV" Button

### DIFF
--- a/rails-app/app/assets/stylesheets/main.css
+++ b/rails-app/app/assets/stylesheets/main.css
@@ -271,6 +271,7 @@ textarea.input100 {
   height: 62px;
   background-color: transparent;
   border-radius: 31px;
+  text-decoration:none;
 
   font-family: Ubuntu-Bold;
   font-size: 16px;

--- a/rails-app/app/controllers/settings_controller.rb
+++ b/rails-app/app/controllers/settings_controller.rb
@@ -19,8 +19,8 @@ class SettingsController < ApplicationController
     flash[:notice] = "All visit records deleted"
     redirect_to settings_path
   end
-  
-  def exportcsv
+
+  def export_csv
     @visits = Visit.all
     respond_to do |format|
     format.html

--- a/rails-app/app/views/settings/index.html.erb
+++ b/rails-app/app/views/settings/index.html.erb
@@ -43,7 +43,6 @@
 			</div>
 
 			<%=link_to 'Export to CSV', settings_exportcsv_path(:format => "csv")%>
-			<%=link_to 'Export to Excel', settings_exportcsv_path(:format => "xsl")%>
 
 		</form>
 
@@ -56,6 +55,16 @@
         </button>
       </div>
     </form>
+
+		<form class="contact100-form export-csv" action="/exportcsv" method="get">
+			<div class="container-contact100-form-btn">
+        <button class="contact100-form-btn" type="submit">
+          <span>
+            Export to CSV
+          </span>
+        </button>
+      </div>
+		</form>
 
 	</div>
 </div>

--- a/rails-app/app/views/settings/index.html.erb
+++ b/rails-app/app/views/settings/index.html.erb
@@ -41,9 +41,6 @@
 					</span>
 				</button>
 			</div>
-
-			<%=link_to 'Export to CSV', settings_exportcsv_path(:format => "csv")%>
-
 		</form>
 
     <form class="contact100-form validate-form" action="/delete_visits" method="get">
@@ -56,15 +53,9 @@
       </div>
     </form>
 
-		<form class="contact100-form export-csv" action="/exportcsv" method="get">
 			<div class="container-contact100-form-btn">
-        <button class="contact100-form-btn" type="submit">
-          <span>
-            Export to CSV
-          </span>
-        </button>
+            <%=link_to 'Export to CSV', settings_export_csv_path(:format => "csv"),:class => "contact100-form-btn"%>
       </div>
-		</form>
 
 	</div>
 </div>

--- a/rails-app/config/routes.rb
+++ b/rails-app/config/routes.rb
@@ -27,5 +27,5 @@ Rails.application.routes.draw do
   post '/settings' => 'settings#update'
   get '/delete_visits' => 'settings#delete_visits'
 
-  get '/settings/exportcsv' => 'settings#exportcsv'
+  get '/settings/export_csv' => 'settings#export_csv'
 end

--- a/rails-app/db/seeds.rb
+++ b/rails-app/db/seeds.rb
@@ -19,9 +19,11 @@ elsif Rails.env.development?
   attrs = row.to_hash.slice(*fields).transform_values { |v| v || "none" }
   Voter.create!(attrs)
   end
-else
+elsif
   CSV.foreach(Dir.pwd + "/db/Cntywd_020819.csv", headers: true) do |row|
   attrs = row.to_hash.slice(*fields).transform_values { |v| v || "none" }
   Voter.create!(attrs)
 end
+else
+  visit = Visit.create(:created_at => '2019-04-24 19:42:31', :updated_at => '2019-04-24 19:45:00', :voter_id => '0123456789')
 end


### PR DESCRIPTION
## Description
Added style to the "export to csv" button so it matches the rest of the page

## Pull Request Changes
List changes made in the context of a developer.
Ex:
- Minor css changes

## Images:
<img width="858" alt="Screen Shot 2019-04-25 at 11 05 18 AM" src="https://user-images.githubusercontent.com/28554571/56757870-235c4080-674a-11e9-83ba-ca9d49f71476.png">

<img width="1228" alt="Screen Shot 2019-04-25 at 11 05 30 AM" src="https://user-images.githubusercontent.com/28554571/56757874-25260400-674a-11e9-98d0-64270dd066b3.png">
