### PR TITLE
Use textarea for admin note

### DIFF
--- a/rails-app/app/views/settings/index.html.erb
+++ b/rails-app/app/views/settings/index.html.erb
@@ -29,7 +29,7 @@
 				Default Voter Note
 			</div>
 			<div class="wrap-input100 validate-input" data-validate="Please enter a voter note">
-				<input class="input100" type="text" name="note" value=<%= @note %> >
+        <textarea class="input100" type="text" name="note"><%= @note %></textarea>
 				<span class="focus-input100"></span>
 			</div>
 


### PR DESCRIPTION
## Description
- Make note an expandable textbox

## GitHub Issue
#168

## Pull Request Changes
- Use `textarea` for admin note

## Screenshots
![image](https://user-images.githubusercontent.com/25378966/56877416-c343f380-6a02-11e9-9d4e-664f641d4576.png)
