### PR TITLE
Add get_default_note graphql query

### DIFF
--- a/rails-app/app/graphql/types/query_type.rb
+++ b/rails-app/app/graphql/types/query_type.rb
@@ -46,6 +46,7 @@ module Types
       Setting['canvasser_password']
     end
 
+    # TODO: Remove if not being used
     field :get_note_by_id, String, null: true do
       description "Retrieve note for voter"
       argument :id, ID, required: true
@@ -57,6 +58,13 @@ module Types
       else
         voter_note
       end
+    end
+
+    field :get_default_note, String, null: true do
+      description "Retrieve default note"
+    end
+    def get_default_note()
+      Setting['note']
     end
 
   end


### PR DESCRIPTION
## Description
- Adds a query to get the default note

## GitHub Issue
#174

## Pull Request Changes
- Add graphql query to retrieve the default note

## Screenshots
![image](https://user-images.githubusercontent.com/25378966/56932044-0cde1e00-6a97-11e9-8323-f1e5bc24bfab.png)
