### PR TITLE
Update admin dashboard to show reset campaign app

### DIFF
--- a/rails-app/app/controllers/settings_controller.rb
+++ b/rails-app/app/controllers/settings_controller.rb
@@ -23,7 +23,9 @@ class SettingsController < ApplicationController
 
   def delete_visits
     Visit.delete_all
-    flash[:notice] = "All visit records deleted"
+    Setting.houses_canvassed = 0
+    Setting.volunteers = 0
+    flash[:notice] = "Campaign Reset"
     redirect_to settings_path
   end
 

--- a/rails-app/app/views/settings/index.html.erb
+++ b/rails-app/app/views/settings/index.html.erb
@@ -59,7 +59,7 @@
         <div class="container-contact100-form-btn">
           <button class="contact100-form-btn" type="submit">
             <span>
-              Reset Visited Records
+              Reset Campaign
             </span>
           </button>
         </div>

--- a/rails-app/spec/features/settings_spec.rb
+++ b/rails-app/spec/features/settings_spec.rb
@@ -27,8 +27,10 @@ RSpec.feature "user logs in" do
     click_on "Log in"
 
     visit settings_path
-    click_on "Reset Visited Records"
-    expect(page).to have_content("All visit records deleted")
+    click_on "Reset Campagin"
+    expect(page).to have_content("Campaign Reset")
     expect(Visit.count).to eq 0
+    expect(Setting.volunteers).to eq 0
+    expect(Setting.houses_canvassed).to eq 0
   end
 end

--- a/rails-app/spec/features/settings_spec.rb
+++ b/rails-app/spec/features/settings_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "user logs in" do
     click_on "Log in"
 
     visit settings_path
-    click_on "Reset Campagin"
+    click_on "Reset Campaign"
     expect(page).to have_content("Campaign Reset")
     expect(Visit.count).to eq 0
     expect(Setting.volunteers).to eq 0


### PR DESCRIPTION
## Description
Describe your changes made in the context of a user/technical user.
- Update `Reset Visits Table` button on `Admin Dashboard` to `Reset Campaign`
- `Reset Campaign` button clears stats

## GitHub Issue
Place a link to the GitHub issue:
NA

## Pull Request Changes
List changes made in the context of a developer.
- Update `Reset Visits Table` button on `Admin Dashboard` to `Reset Campaign`
- `Reset Campaign` button clears stats

## Screenshots (optional)
<img width="1209" alt="Screen Shot 2019-05-08 at 8 14 31 PM" src="https://user-images.githubusercontent.com/27448527/57424878-191c5680-71ce-11e9-805d-14f14fdd6abf.png">


