### PR TITLE
Point campaignify.net/manager to rails app

### DIFF
--- a/config/deploy/campaignify-staging/ingress.yml
+++ b/config/deploy/campaignify-staging/ingress.yml
@@ -5,6 +5,7 @@ metadata:
   name: ingress-service
   annotations:
     kubernetes.io/ingress.class: traefik
+    traefik.frontend.rule.type: PathPrefixStrip
 spec:
   rules:
     - host: staging.campaignify.net
@@ -20,6 +21,13 @@ spec:
           - path: /
             backend:
               serviceName: react-cluster-ip-service
+              servicePort: 80
+    - host: campaignify.net
+      http:
+        paths:
+          - path: /manager
+            backend:
+              serviceName: rails-cluster-ip-service
               servicePort: 80
     - host: api.campaignify.net
       http:


### PR DESCRIPTION
## Description
- campaignify.net/manager should point to rails app

![image](https://user-images.githubusercontent.com/25378966/57563990-e30bdd80-7359-11e9-98b4-c54ad9cbe0ca.png)
